### PR TITLE
changed the added noise in detectability plots

### DIFF
--- a/steamed_HAMs.ipynb
+++ b/steamed_HAMs.ipynb
@@ -1021,7 +1021,8 @@
    "outputs": [],
    "source": [
     "\n",
-    "\n",
+    "#Load all files required to run model.  Can substitute in own reference MHD simulation and DMO simulation\n",
+    "#here\n",
     "\n",
     "\n",
     "f=np.load(directory+'/TNGhal.npz',allow_pickle=True)\n",
@@ -1064,7 +1065,9 @@
    "outputs": [],
    "source": [
     "indexes=load_index(N_shell,N_cell)\n",
-    "#may take a while when first running, but saved for future runs"
+    "#may take a while when first running, but saved for future runs\n",
+    "\n",
+    "#this is for producing the concentric shells of the magnetic bubbles"
    ]
   },
   {
@@ -1186,7 +1189,7 @@
     }
    ],
    "source": [
-    "\n",
+    "#produce the magnetic profiles.  Can set RESET=True to recompute, otherwise step will be skipped once previously computed\n",
     "if((not (os.path.isfile('A_profiles.npz')))or ( reset)):\n",
     "    Bn=np.sqrt(np.sum(BOG**2,axis=3))\n",
     "    A,Masses,Envirs=get_B_profiles(pos,M,Bn,dens,indexes,N_shell,f_thresh=100,Bavg=1e-14,Mthresh=Mass_threshold,dims=64)\n",
@@ -1283,6 +1286,11 @@
     }
    ],
    "source": [
+    "#produces the emulated version of the reference simulation and displays them.  Note that there are large discrepancies\n",
+    "#between the model and reference simulation owning to the highly simplified framework applied here.  This is a compromise between speed (as compared\n",
+    "# to full MHD simulations) and understanding (as in painting in magnetic field with machine learning)\n",
+    "#the model would not converge to the true refernce magnetic field even if mass threshold was set to zero\n",
+    "\n",
     "B_polluted=emulateBubbles(pos,M,dens,Bavg,indexes,dims=64,rescale_factor=1,Mthresh=Mass_threshold)\n",
     "#A,Masses and Envirs are loaded from file unless specified.  Rescale factor is 1 as we are feeding the \n",
     "#sim back into itself\n",
@@ -1420,6 +1428,12 @@
     }
    ],
    "source": [
+    "#Renormalises the galactic pollution field.  The strength of rotation the rotation measure is typically suppressed by a factor of about 7-8 with\n",
+    "#the current set up.  It is not caused by ther incorrect field coherence length (I have tried it with always setting the field to be in a single direction).\n",
+    "#The underestimate is likely caused by the spherical averaging procedure essentially ignoring small pockets of relatively \n",
+    "#strong magnetic fields\n",
+    "\n",
+    "\n",
     "box_size=100 #in Mpc\n",
     "znorm=1\n",
     "#the redshift at which the refence simulation agrees with the HAM model.  If the model was perfect then this parameter \n",
@@ -1513,6 +1527,12 @@
     }
    ],
    "source": [
+    "#produces the painted field for the Sibelius simulation, normalised to the factor found for TNG,\n",
+    "#and adding a primordial component.  You could probably ignore the primordial part for a field as weak\n",
+    "#as it is in TNG however\n",
+    "\n",
+    "\n",
+    "\n",
     "#this is extremely slow, so may want to experiment with higher threshold masses.  \n",
     "\n",
     "B_sib=emulateBubbles(pos_sib,M_sib,dens_sib,Bavg,indexes,dims=64,rescale_factor=936.8/2/100,Mthresh=Mass_threshold)*C+p_field_gen(dens_sib,amplitude=1e-14,frac=0.1,scale=16)\n",
@@ -1590,6 +1610,9 @@
    "source": [
     "#for further visualisation\n",
     "#requires use of cosmotool\n",
+    "\n",
+    "#next few cells are for visualisation of the data, but were not used in the paper\n",
+    "\n",
     "\n",
     "import cosmotool\n",
     "\n",
@@ -1719,6 +1742,9 @@
     }
    ],
    "source": [
+    "#fig 1, comparing TNG and model\n",
+    "\n",
+    "\n",
     "fig_size = (6, 5.5)\n",
     "fig, axes = plt.subplots(1,2, sharex=True, sharey=True, figsize=fig_size)\n",
     "\n",
@@ -1780,6 +1806,8 @@
     }
    ],
    "source": [
+    "#fig 2 histograms of magnetic field\n",
+    "\n",
     "plt.yscale('log')\n",
     "s1=plt.hist(np.log10(Bn.ravel()+1e-15),alpha=1,bins=300,histtype='step')#s=plt.hist(np.log10(HAM+1e-15),alpha=0.3,bins=300)\n",
     "s2=plt.hist(np.log10(HAM.ravel()+1e-15),alpha=0.3,bins=300,histtype='step')\n",
@@ -1817,7 +1845,7 @@
     "densma=3.4\n",
     "Bimi=-11\n",
     "Bima=2\n",
-    "\n",
+    "#fig 3, 2-d histogram density vs B \n",
     "\n",
     "\n",
     "\n",
@@ -2165,7 +2193,7 @@
     }
    ],
    "source": [
-    "\n",
+    "#fig 4, line of sight accumulated RM\n",
     "def RMtemp(Blist,dens,RM_const):\n",
     "    s=dens.shape\n",
     "    RM=np.zeros((s[0],s[1],s[2],3),dtype=float)\n",
@@ -2304,7 +2332,7 @@
     }
    ],
    "source": [
-    "\n",
+    "#fig 5 left, density field with accompanying filaments\n",
     "dhp=cosmotool.spherical_projection(nside,np.transpose(dens_sib/np.mean(dens_sib),(2,1,0)), min_distance=3, max_distance=dist, progress=1,integrator_id=1)/dist\n",
     "\n",
     "colours=['brown','red','orange','yellow','lime','green','cyan','blue','purple','indigo','violet','gold','silver','pink','black']\n",
@@ -2391,7 +2419,7 @@
     }
    ],
    "source": [
-    "\n",
+    "#fig 5 right, RM field, without any foregrounds or backgrounds\n",
     "dirs=radial(512)\n",
     "chi=5./7\n",
     "n_const=2.84615e-30/1.67e-24*chi\n",
@@ -2445,7 +2473,7 @@
     }
    ],
    "source": [
-    "\n",
+    "#fig 6, RM versus radius for each of the filaments\n",
     "\n",
     "fil_hp,fil_all=get_seps(fils,nside,Np=100)\n",
     "\n",
@@ -2692,6 +2720,11 @@
     }
    ],
    "source": [
+    "#fig 7 producing the foreground and background.  Foreground is computed from standard deviation in signal\n",
+    "#and is a realisation assuming that the noise of is normal around zero.  Backround assumes that a \n",
+    "#sightline at a certain redshift has accrued a value from the distribution in fig. 4.  An illuminating source\n",
+    "#is then chosen using a redshift distribution defined by TNG.  Only masses above 10^12 M_sol are allowed to\n",
+    "#act as sources\n",
     "zi=0.25\n",
     "zu=np.where(abs(zi-zo)==np.min(abs(zi-zo)))[0][0]\n",
     "nsides=[2**n for n in range(8,3,-1)]\n",
@@ -2820,6 +2853,7 @@
     }
    ],
    "source": [
+    "#fig 7 right\n",
     "MW_plt(abs(RMhp.copy()+true_bg.copy()+0*N_fg.copy()),0,True,\"z=0.25 Background\",-2.,2.5,'cividis',\"B\",None,r'$\\rm RM\\:[rad\\,m^{-2}]$')\n",
     "\n",
     "\n",
@@ -2900,7 +2934,8 @@
    ],
    "source": [
     "\n",
-    "\n",
+    "#fig 8. calculate the width of the filaments.  Assumes an inherent noise of 0.1 radm^-2 from instrument, without which \n",
+    "#the filament doesn't seem to have an edge\n",
     "\n",
     "\n",
     "\n",
@@ -2908,8 +2943,14 @@
     "############################\n",
     "if(hm==None):\n",
     "    halo_map=cosmotool.spherical_projection(nside,np.transpose(((dens_sib/np.mean(dens_sib))>200)*1.0,(2,1,0)), min_distance=0, max_distance=dist, progress=1,integrator_id=1)/dist\n",
+    "    halo_map2=cosmotool.spherical_projection(nside,np.transpose(((dens_sib/np.mean(dens_sib))>50)*1.0,(2,1,0)), min_distance=0, max_distance=dist, progress=1,integrator_id=1)/dist\n",
     "    hm=True\n",
     "U=np.where(halo_map==0)[0]\n",
+    "#these are sightlines which do not pass through any virial region\n",
+    "U2=np.where(halo_map2==0)[0]\n",
+    "#sightlines that are well outside any halo or filament\n",
+    "sig_bg=np.std(abs(RMhp[U2]))\n",
+    "\n",
     "\n",
     "N_fil=len(fil_hp)\n",
     "sizes=np.linspace(0.05,10,200)\n",
@@ -2965,6 +3006,7 @@
     }
    ],
    "source": [
+    "#plotting fig 8.\n",
     "colours=['brown','red','orange','yellow','lime','green','cyan','blue','purple','indigo','violet','gold','silver','pink','black']\n",
     "\n",
     "fil_sizes=np.zeros(8,dtype=float)\n",
@@ -2975,8 +3017,8 @@
     "        \n",
     "        col=colours[i]\n",
     "        \n",
-    "        plt.plot(sizes,(ld1darr_fil_q[:,i]/np.sqrt(0.01+ld1darr_fil_q_N[:,i]**2)),color=col)\n",
-    "        s=(ld1darr_fil_q[:,i]/np.sqrt(0.01+ld1darr_fil_q_N[:,i]**2))\n",
+    "        plt.plot(sizes,(ld1darr_fil_q[:,i]/np.sqrt(sig_bg**2+ld1darr_fil_q_N[:,i]**2)),color=col)\n",
+    "        s=(ld1darr_fil_q[:,i]/np.sqrt(sig_bg**2+ld1darr_fil_q_N[:,i]**2))\n",
     "        #print(s,ld1darr_fil_q_N[:,i])\n",
     "        fil_sizes[i]=sizes[np.where(s==np.max(s))[0][0]]\n",
     "       \n",
@@ -3010,7 +3052,7 @@
     }
    ],
    "source": [
-    "\n",
+    "#fig 9. Determining what fraction of current galactic fg we could tolerate while still detecting filaments\n",
     "sizes=np.linspace(0.1,10,100)\n",
     "fgal=np.logspace(-3,0,50)\n",
     "ld1darr_f_fg_N=np.zeros((fgal.size,N_fil),dtype=float)\n",
@@ -3056,14 +3098,14 @@
     }
    ],
    "source": [
-    "\n",
+    "#fig 9\n",
     "\n",
     "\n",
     "for i,fh in enumerate(fil_hp):\n",
     "        \n",
     "        col=colours[i]\n",
     "        \n",
-    "        plt.plot(fgal,(((ld1darr_f[:,i])/np.sqrt(0.01+ld1darr_f_N[:,i]**2+ld1darr_f_fg_N[:,i]**2))),color=col)\n",
+    "        plt.plot(fgal,(((ld1darr_f[:,i])/np.sqrt(sig_bg**2+ld1darr_f_N[:,i]**2+ld1darr_f_fg_N[:,i]**2))),color=col)\n",
     "        \n",
     "        \n",
     "        \n",
@@ -3475,13 +3517,7 @@
       "0.15%, z=0.25, S=4740\n",
       "0.15%, z=0.28, S=6877\n",
       "0.15%, z=0.32, S=9972\n",
-      "0.15%, z=0.36, S=14423\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "0.15%, z=0.36, S=14423\n",
       "0.15%, z=0.40, S=20802\n",
       "0.15%, z=0.45, S=29818\n",
       "0.15%, z=0.50, S=42412\n",
@@ -3504,6 +3540,10 @@
     }
    ],
    "source": [
+    "#fig 10.  Computes the optimal redshift for fig 10, assuming 1000 ish available sources per degree ouyt to z=1\n",
+    "#More distant sources passes through extra structures of unknown density and magnetic field, so despite being\n",
+    "#more numerous can confuse the signal\n",
+    "\n",
     "\n",
     "#find the optimal redshift for a given filament size\n",
     "#need redshift distribution of number of sources,\n",
@@ -3558,8 +3598,13 @@
     "\n",
     "cTs=cTs#[::3]\n",
     "zref=0.5\n",
-    "ccc=int(cTs[np.where(abs(zs-zref)==np.min(abs(zs-zref)))[0][0]]/(12*256**2))\n",
-    "print('ccc:',ccc)\n",
+    "#------------------------------------------------------------------------\n",
+    "#change this number to determine the number of sources per square degree\n",
+    "#currently set to 1000, whether or not this results in detectable filaments\n",
+    "#depends on the nature of the magnetic field\n",
+    "\n",
+    "#minimum is 4 sources, even if there shouldn't be any detected\n",
+    "#------------------------------------------------------------------------\n",
     "ccc=20000\n",
     "i=np.where(abs(zs-1)==np.min(abs(zs-1)))[0][0]\n",
     "S=(int(cTs[i])//ccc+4)/41252.96125\n",
@@ -3618,7 +3663,7 @@
     "                            ld1darr_fil_z[i,m]=np.mean(((abs(temp))))\n",
     "                            ld1darr_fil_z_N[i,m]=np.std(((abs(temp))))/np.sqrt(S)\n",
     "                            ld1darr_fil_z_fg[i,m]=np.std(((abs(np.random.choice(N_fg[x]*f,size=S)))))\n",
-    "                            ld1darr_fil_z_bg[i,m]=np.median(((abs(bg_temp))))\n",
+    "                            ld1darr_fil_z_bg[i,m]=np.mean(((abs(bg_temp))))\n",
     "                            \n"
    ]
   },
@@ -3651,7 +3696,7 @@
     }
    ],
    "source": [
-    "\n",
+    "#fig 10\n",
     "x=np.where(zs>0.05)[0]\n",
     "for i,fh in enumerate(fil_hp):\n",
     "        \n",
@@ -3674,7 +3719,7 @@
     "\n",
     "plt.show()\n",
     "\n",
-    "[sum((((ld1darr_fil_z[:,i])/np.sqrt(ld1darr_fil_z_N[:,i]**2+ld1darr_fil_z_bg[:,i]**2+ld1darr_fil_z_fg[:,i]**2+0.01)))>3)>0 for i in range(8)]"
+    "[sum((((ld1darr_fil_z[:,i])/np.sqrt(sig_bg**2+ld1darr_fil_z_N[:,i]**2+ld1darr_fil_z_bg[:,i]**2+ld1darr_fil_z_fg[:,i]**2+0.01)))>3)>0 for i in range(8)]"
    ]
   },
   {
@@ -3759,7 +3804,7 @@
     }
    ],
    "source": [
-    "\n",
+    "#fig 11, repeat but for 100,000 sources per degree, very slow to run\n",
     "#find the optimal redshift for a given filament size\n",
     "#need redshift distribution of number of sources,\n",
     "#as well as the expected noise at each redshift\n",
@@ -3875,7 +3920,7 @@
     "                            ld1darr_fil_z_N2[i,m]=np.std(((abs(temp))))/np.sqrt(S)\n",
     "                            ld1darr_fil_z_fg2[i,m]=np.std(((abs(np.random.choice(N_fg[x]*f,size=S)))))\n",
     "                            \n",
-    "                            ld1darr_fil_z_bg2[i,m]=np.median(((abs(bg_temp))))\n",
+    "                            ld1darr_fil_z_bg2[i,m]=np.mean(((abs(bg_temp))))\n",
     "                            \n"
    ]
   },
@@ -3909,7 +3954,7 @@
     "\n",
     "plt.show()\n",
     "\n",
-    "[sum((((ld1darr_fil_z[:,i])/np.sqrt(ld1darr_fil_z_N2[:,i]**2+ld1darr_fil_z_bg2[:,i]**2+ld1darr_fil_z_fg2[:,i]**2+0.01)))>3)>0 for i in range(8)]"
+    "[sum((((ld1darr_fil_z[:,i])/np.sqrt(sig_bg**2+ld1darr_fil_z_N2[:,i]**2+ld1darr_fil_z_bg2[:,i]**2+ld1darr_fil_z_fg2[:,i]**2+0.01)))>3)>0 for i in range(8)]"
    ]
   },
   {
@@ -3931,9 +3976,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "p3env",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "p3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -3945,7 +3990,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Was fixed at 0.1 radm^-2 and was supposed to be due to instrument noise, but didn't make physical sense.  Now comes from noise far from filaments in standard deviation of RM sightlines outside all halos, with value 0.15 radm^-2, making filaments a bit harder to detect.  Made sure to propagate this so that the filament width was also correctly measured.  Also added explanation for changing the number of sources per square degree.